### PR TITLE
Add options for quiet debugging (and verbose too)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Usage in haxe builds:
 # turn on pretty printing:
 -D closure_prettyprint
 
-# overwrite original output rather then generating a .min.js next to it
+# overwrite original output rather then generating a .min.js next to it:
 -D closure_overwrite
+
+# change the level of debugging information:
+-D closure_quiet
+-D closure_verbose
 ```

--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -24,6 +24,8 @@ class Compiler {
       '--compilation_level', #if closure_advanced 'ADVANCED' #else 'SIMPLE' #end,
       '--js', out,
       '--js_output_file', min,
+      #if closure_quiet '--warning_level', 'QUIET', #end
+      #if closure_verbose '--warning_level', 'VERBOSE', #end
     ]);
     
     #if closure_overwrite


### PR DESCRIPTION
My code is generating many `Suspicious code. This code lacks side-effects. Is there a bug?` warnings.

Most of them seem to be from `map[x] = y` setters leaving extra `y;` statements around the place.  I imagine these would be cleaned up by either the analyzer or DCE, but I'm not using either on this project :)
