### PR TITLE
added externs and removed requirement for .js file

### DIFF
--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -12,8 +12,8 @@ class Compiler {
   
   static function compile() {
     var out = haxe.macro.Compiler.getOutput();
-    if (!out.endsWith('.js'))
-      Context.error('Expected .js extension for output file $out', Context.currentPos());
+   // if (!out.endsWith('.js'))
+    //  Context.error('Expected .js extension for output file $out', Context.currentPos());
     
     var min = out.substr(0, out.length - 3) + '.min.js';
     
@@ -24,6 +24,7 @@ class Compiler {
       '--compilation_level', #if closure_advanced 'ADVANCED' #else 'SIMPLE' #end,
       '--js', out,
       '--js_output_file', min,
+      #if closure_externs '--externs','extern.js', #end
     ]);
     
     #if closure_overwrite

--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -12,8 +12,8 @@ class Compiler {
   
   static function compile() {
     var out = haxe.macro.Compiler.getOutput();
-   // if (!out.endsWith('.js'))
-    //  Context.error('Expected .js extension for output file $out', Context.currentPos());
+    if (!out.endsWith('.js'))
+       Context.warning('Expected .js extension for output file $out', Context.currentPos());
     
     var min = out.substr(0, out.length - 3) + '.min.js';
     
@@ -24,7 +24,9 @@ class Compiler {
       '--compilation_level', #if closure_advanced 'ADVANCED' #else 'SIMPLE' #end,
       '--js', out,
       '--js_output_file', min,
-      #if closure_externs '--externs','extern.js', #end
+      #if closure_externs 
+       '--externs',Context.definedValue("closure_externs"), 
+      #end
     ]);
     
     #if closure_overwrite


### PR DESCRIPTION
Probably a better way to do this but.

extern.js is in root and should have "@:keep" functions defined as 

function toCsv(){};
function setup(){};