### PR TITLE
`language_in` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library plugs in the google closure compiler into your build.
 
 Usage in haxe builds:
   
-```
+```shell
 -lib closure
 
 # turn on advanced compilation:

--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ Usage in haxe builds:
 
 # overwrite original output rather then generating a .min.js next to it
 -D closure_overwrite
+
+# optional. set specific ecmascript version
+-D closure_language_in=ECMASCRIPT5
 ```

--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -27,6 +27,12 @@ class Compiler {
       #if closure_externs 
        '--externs',Context.definedValue("closure_externs"), 
       #end
+      #if closure_language_in
+      '--language_in',Context.definedValue("closure_language_in"),
+      #end         
+      #if closure_pretty_print
+      '--formatting','pretty_print',
+      #end
     ]);
     
     #if closure_overwrite

--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -29,9 +29,6 @@ class Compiler {
       #end
       #if closure_language_in
       '--language_in',Context.definedValue("closure_language_in"),
-      #end         
-      #if closure_pretty_print
-      '--formatting','pretty_print',
       #end
     ]);
     


### PR DESCRIPTION
I've added a flag: `-D closure_language_in=ECMASCRIPT5`. I needed language_in to use it with a project where I include an external library (pixi) that requires it to change this value, otherwise it gives errors.

* `--language_in` https://developers.google.com/closure/compiler/docs/limitations