### PR TITLE
Added control flag

### DIFF
--- a/src/closure/Compiler.hx
+++ b/src/closure/Compiler.hx
@@ -9,7 +9,7 @@ import sys.io.File;
 class Compiler {
 
   static function use() {
-    #if !closure_disabled
+    #if (!closure_disabled && !closure_slavemode)
     Context.onAfterGenerate(compile);
     #end
   }


### PR DESCRIPTION
Added new flag `closure_slavemode` to disable minification without setting `closure_disabled` in order to avoid confusion when controlled by other tools like Modular (https://github.com/elsassph/haxe-modular/pull/80).